### PR TITLE
Increase JWT token expiration time

### DIFF
--- a/backend/heka/users/views.py
+++ b/backend/heka/users/views.py
@@ -46,7 +46,7 @@ class LoginView(APIView):
         
         payload = {
             "id": user.id,
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(minutes=60),
+            "exp": datetime.datetime.utcnow() + datetime.timedelta(days=1),
             "iat": datetime.datetime.utcnow()
         }
 


### PR DESCRIPTION
Instead of 60 minutes for the expiration time of the JWT token, it is one day. Because it is easier to test all API's in this way. 