### PR TITLE
Frontend: Backend Connection for Forget Password and Error Messages

### DIFF
--- a/heka-front/src/api/Backend/Backend.js
+++ b/heka-front/src/api/Backend/Backend.js
@@ -11,6 +11,17 @@ export const postRegister = (email, username, password, is_expert) => {
     is_expert,
   });
 };
+
+export const postEmail = (email) => {
+  return ApiInstance.post('/api/user/forget_password', { email});
+};
+
+export const postNewPassword = (code,new_password,confirm_new_password) => {
+  return ApiInstance.post('/api/user/reset_password', { code,new_password,confirm_new_password});
+};
+
+
+
 export const postCreatePost = (
   title,
   body,

--- a/heka-front/src/pages/ForgotPassword/ForgotPassword.css
+++ b/heka-front/src/pages/ForgotPassword/ForgotPassword.css
@@ -64,6 +64,7 @@ input:focus {
   margin: 10px 0;
   padding: 10px;
   border-radius: 3px 3px 3px 3px;
+  width: 325px;
 }
 .login-button {
   display: flex;
@@ -191,7 +192,7 @@ input:focus {
 #Registered {
   text-align: center;
   padding-top: 1rem;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
   padding-bottom: 2rem;
   margin-bottom: 0;
 }

--- a/heka-front/src/pages/ForgotPassword/ForgotPassword.js
+++ b/heka-front/src/pages/ForgotPassword/ForgotPassword.js
@@ -21,12 +21,13 @@ const ForgotPasswordForm = () => {
   const [password1, setPassword1] = useState('');
   const [password2, setPassword2] = useState('');
   const [confirmationErr, setConfirmationErr] = useState();
+  const [validationCodeErr, setValidationCodeErr] = useState(false);
   const [Done, setDone] = useState(false);
 
   const handleSubmit = async (e) => {
     console.log('saved to firestore , input: ' + username);
     e.preventDefault();
-    //const response = await BackendApi.postLogin(username, password);
+    const response = await BackendApi.postEmail(username);
    /* if (response.status === 200) {
       setIsAuthenticated(true);
     } else if (response.status === 403) {
@@ -36,20 +37,25 @@ const ForgotPasswordForm = () => {
 
     if (validator.isEmail(username)) {
       //alert(username);
-      setIsForgotPassword(false);
-      setIsNewPassword(true);
+      if(response.status === 200 ) {
+        setIsForgotPassword(false);
+        setIsNewPassword(true);
+      }
+      else if (response.status === 400) {
+        setWrong(true);
+      }
+      
       //navigate('/', {replace: true});       // sonradan ekledim
     } else {
       setErrMessage(true);
     }
   };
 
-  
 
   const handleNewPasswordSubmit = async (e) => {
     console.log('saved to firestore , input: ' + username);
     e.preventDefault();
-    //const response = await BackendApi.postLogin(username, password);
+    const response = await BackendApi.postNewPassword(validationCode, password1, password2);
    /* if (response.status === 200) {
       setIsAuthenticated(true);
     } else if (response.status === 403) {
@@ -59,14 +65,25 @@ const ForgotPasswordForm = () => {
 
     if (password1 == password2) {
       //alert(username);
-      setIsForgotPassword(false);
-      setIsNewPassword(false);
-      setDone(true);
+      if (response.status === 200) {
+        setIsForgotPassword(false);
+        //setIsEmailValidation(false);
+        setIsNewPassword(false);
+        setDone(true);
+      }
+      else if (response.status === 500) {
+        setValidationCodeErr(true);
+        
+      }
+      
     } else {
       setConfirmationErr(true);
     
     }
   };
+  
+
+ 
   const handleSuccessSubmit = async (e) => {
     //console.log('saved to firestore , input: ' + username);
     e.preventDefault();
@@ -123,7 +140,7 @@ const ForgotPasswordForm = () => {
               {wrong_email_password && !err_message ? (
                 <div className='error-msg'>
                   <i className='fa fa-times-circle'></i>
-                  Invalid username or password
+                  The Heka account associated with the "{username}" was not found.
                 </div>
               ) : null}
               
@@ -214,6 +231,13 @@ const ForgotPasswordForm = () => {
                 <div className='error-msg'>
                   <i className='fa fa-times-circle'></i>
                   Password and Confirm Password must be matched
+                </div>
+              ) : null}
+
+              {(validationCodeErr) ? (
+                <div className='error-msg'>
+                  <i className='fa fa-times-circle'></i>
+                  {" "} Incorrect validation code
                 </div>
               ) : null}
 


### PR DESCRIPTION
### About Feature:
I implemented forget password functionality in previous versions without backend connection since backend team have not provide forget password functionality yet. Now, I implemented backend connection for forget password functionality.

I also added error messages for all possible errors as follows:

-  Our application will give error message "The Heka account associated with the "{email}" was not found" if user enters a email that is not registered yet.
-  Our application will give error message "Incorrect validation code"  if user enters incorrect validation code. 
- Our application will give error message "Password and Confirm Password must be matched"  if user enters two different password for confirm password section. 

➡️ For more details, you can look at #415 



### 🔎 Reviewer:  
 @umutdenizsenerr 
### ⏰ Deadline: 
04.12.2022 23.59