### PR TITLE
Update Dockerfile and docker-compose to run more efficiently

### DIFF
--- a/heka-front/Dockerfile
+++ b/heka-front/Dockerfile
@@ -1,14 +1,11 @@
 
-
 # Dockerfile
 # ==== CONFIGURE =====
-# Use a Node 16 base image
-FROM node:18-alpine 
+FROM node:18-alpine as build
 # Set the working directory to /app inside the container
 WORKDIR /app
 # Optimization
 COPY ./package.json .
-RUN npm install --legacy-peer-deps
 # ==== BUILD =====
 # Install dependencies (npm ci makes sure the exact versions in the lockfile gets installed)
 RUN npm ci --legacy-peer-deps
@@ -16,7 +13,11 @@ RUN npm ci --legacy-peer-deps
 COPY . .
 # Build the app
 RUN npm run build
+
 # ==== RUN =======
+FROM node:18-alpine as run
+WORKDIR /app
+COPY --from=build /app/build ./build
 # Set the env to "production"
 ENV NODE_ENV production
 # Expose the port on which the app will be running (3000 is the default that `serve` uses)

--- a/heka-front/docker-compose.yml
+++ b/heka-front/docker-compose.yml
@@ -2,13 +2,8 @@ version: '3.7'
 
 services:
 
-  sample:
-    container_name: sample
+  front:
+    container_name: front
     build: .
-    volumes:
-      - '.:/app'
-      - '/app/node_modules'
     ports:
       - 3000:3000
-    environment:
-      - CHOKIDAR_USEPOLLING=true


### PR DESCRIPTION
I changed the Dockerfile to run more efficiently. Now it does two stage build. The image size was 1.4Gb in the server. This update reduced it to 200 Mb. 