### PR TITLE
Backend: Change permission for the image annotation endpoints

### DIFF
--- a/backend/heka/annotations/views.py
+++ b/backend/heka/annotations/views.py
@@ -20,7 +20,7 @@ class ImageAnnotationAPIView(APIView):
         return Response(serializer.data["json"], status=status.HTTP_200_OK)
 
 class PostImageAnnotationAPIView(APIView):
-    permission_classes = [IsAuthenticated]
+    permission_classes = [AllowAny]
     @swagger_auto_schema(responses={200:ImageAnnotationSerializer(many=True)})
     def get(self, request, post_slug=None):
         annotation = ImageAnnotation.objects.filter(post_slug=post_slug)


### PR DESCRIPTION
Permissions need to change. Authentication was unnecessary for the image annotations. It is changed to the allow any.