### PR TITLE
Backend: Text annotation endpoints

### DIFF
--- a/backend/heka/annotations/models.py
+++ b/backend/heka/annotations/models.py
@@ -1,23 +1,11 @@
 from django.db import models
 
-
-#
-# {
-#   "@context": "http://www.w3.org/ns/anno.jsonld",
-#   "id": "http://example.org/anno20",
-#   "type": "Annotation",
-#   "body": {
-#     "source": "http://example.org/video1",
-#     "purpose": "describing",
-#     "selector": {
-#       "type": "FragmentSelector",
-#       "conformsTo": "http://www.w3.org/TR/media-frags/",
-#       "value": "xywh=50,50,640,480"
-#     }
-#   },
-#   "target": "http://example.org/image1"
-# }
 class ImageAnnotation(models.Model):
+    post_slug = models.TextField(null=False, blank=False)
+    # Source -> Post slug
+    json = models.JSONField()
+
+class TextAnnotation(models.Model):
     post_slug = models.TextField(null=False, blank=False)
     # Source -> Post slug
     json = models.JSONField()

--- a/backend/heka/annotations/serializers.py
+++ b/backend/heka/annotations/serializers.py
@@ -1,9 +1,15 @@
 from rest_framework import serializers
 
-from .models import ImageAnnotation
+from .models import ImageAnnotation, TextAnnotation
 
 
 class ImageAnnotationSerializer(serializers.ModelSerializer):
     class Meta:
         model = ImageAnnotation
+        fields = ['id', 'post_slug', 'json']
+
+
+class TextAnnotationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TextAnnotation
         fields = ['id', 'post_slug', 'json']

--- a/backend/heka/annotations/urls.py
+++ b/backend/heka/annotations/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
-from .views import ImageAnnotationAPIView, PostImageAnnotationAPIView
+from .views import ImageAnnotationAPIView, PostImageAnnotationAPIView, TextAnnotationAPIView, PostTextAnnotationAPIView
 
 urlpatterns = [
     path("image/<int:annotation_id>", ImageAnnotationAPIView.as_view(), name='get-annotations'),
     path("image/post/<str:post_slug>", PostImageAnnotationAPIView.as_view(), name='get-post-annotations'),
+    path("text/<int:annotation_id>", TextAnnotationAPIView.as_view(), name='get-text-annotations'),
+    path("text/post/<str:post_slug>", PostTextAnnotationAPIView.as_view(), name='get-text-post-annotations'),
 ]

--- a/backend/heka/annotations/views.py
+++ b/backend/heka/annotations/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.shortcuts import render
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
@@ -67,7 +69,8 @@ class PostImageAnnotationAPIView(APIView):
 
             return Response(serializer.data["json"], status=status.HTTP_201_CREATED)
         except Exception as e:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            logging.exception(e)
+            return Response("Wrong request body", status=status.HTTP_400_BAD_REQUEST)
 
 class TextAnnotationAPIView(APIView):
     permission_classes = [AllowAny]

--- a/backend/heka/annotations/views.py
+++ b/backend/heka/annotations/views.py
@@ -77,3 +77,57 @@ class TextAnnotationAPIView(APIView):
         annotation = TextAnnotation.objects.get(pk=annotation_id)
         serializer = TextAnnotationSerializer(annotation)
         return Response(serializer.data["json"], status=status.HTTP_200_OK)
+
+class PostTextAnnotationAPIView(APIView):
+    permission_classes = [AllowAny]
+    @swagger_auto_schema(responses={200:TextAnnotationSerializer(many=True)})
+    def get(self, request, post_slug=None):
+        annotation = TextAnnotation.objects.filter(post_slug=post_slug)
+        serializer = TextAnnotationSerializer(annotation, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(responses={201:TextAnnotationSerializer})
+    def post(self, request, post_slug=None):
+        default_url = request.build_absolute_uri()
+        default_w3c_template = {
+            "@context": "http://www.w3.org/ns/anno.jsonld",
+            "id": "http://example.org/anno20",
+            "type": "Annotation",
+            "body": {
+                "type": "TextualBody",
+                "value": "<p>example!</p>",
+                "format": "text/html",
+                "language": "en"
+
+            },
+            "target": {
+                "source": "http://example.org/post-slug",
+                "selector": {
+                    "type": "TextPositionSelector",
+                    "start": 412,
+                    "end": 795
+                }
+            }
+        }
+
+        try:
+            anno = TextAnnotation(post_slug=post_slug, json=default_w3c_template)
+            anno.save()
+
+            position = request.data["position"]
+
+            default_w3c_template["id"] = default_url.split("post")[0] + str(anno.id)
+            default_w3c_template["body"]["value"] = request.data["data"]["text"]
+            default_w3c_template["target"]["source"] = request.data["data"]["source"]
+
+            default_w3c_template["target"]["selector"]["start"] = position["start"]
+            default_w3c_template["target"]["selector"]["end"] = position["end"]
+
+            anno.json = default_w3c_template
+            serializer = TextAnnotationSerializer(anno)
+            anno.save()
+
+            return Response(serializer.data["json"], status=status.HTTP_201_CREATED)
+        except Exception as e:
+            logging.exception(e)
+            return Response("Wrong request body", status=status.HTTP_400_BAD_REQUEST)

--- a/backend/heka/annotations/views.py
+++ b/backend/heka/annotations/views.py
@@ -4,8 +4,8 @@ from rest_framework import status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from .serializers import ImageAnnotationSerializer
-from .models import ImageAnnotation
+from .serializers import ImageAnnotationSerializer, TextAnnotationSerializer
+from .models import ImageAnnotation, TextAnnotation
 import json
 
 # Create your views here.
@@ -69,3 +69,11 @@ class PostImageAnnotationAPIView(APIView):
         except Exception as e:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+class TextAnnotationAPIView(APIView):
+    permission_classes = [AllowAny]
+
+    @swagger_auto_schema(responses={200:TextAnnotationSerializer(many=True)})
+    def get(self, request, annotation_id=None):
+        annotation = TextAnnotation.objects.get(pk=annotation_id)
+        serializer = TextAnnotationSerializer(annotation)
+        return Response(serializer.data["json"], status=status.HTTP_200_OK)

--- a/backend/heka/annotations/views.py
+++ b/backend/heka/annotations/views.py
@@ -52,20 +52,24 @@ class PostImageAnnotationAPIView(APIView):
             }
         }
         try:
-            anno = ImageAnnotation(post_slug=post_slug, json=default_w3c_template)
-            anno.save()
+
 
             geometry = request.data["geometry"]
             xywh_value = f'xywh={geometry["x"]},{geometry["y"]},{geometry["width"]},{geometry["height"]}'
 
-            default_w3c_template["id"] = default_url.split("post")[0] + str(anno.id)
             default_w3c_template["body"]["value"] = request.data["data"]["text"]
             default_w3c_template["target"]["source"] = request.data["data"]["source"]
             default_w3c_template["target"]["selector"]["value"] = xywh_value
 
-            anno.json = default_w3c_template
-            serializer = ImageAnnotationSerializer(anno)
+            anno = ImageAnnotation(post_slug=post_slug, json=default_w3c_template)
             anno.save()
+
+            default_w3c_template["id"] = default_url.split("post")[0] + str(anno.id)
+            anno.json = default_w3c_template
+
+            anno.save()
+
+            serializer = ImageAnnotationSerializer(anno)
 
             return Response(serializer.data["json"], status=status.HTTP_201_CREATED)
         except Exception as e:
@@ -107,28 +111,30 @@ class PostTextAnnotationAPIView(APIView):
                 "source": "http://example.org/post-slug",
                 "selector": {
                     "type": "TextPositionSelector",
-                    "start": 412,
-                    "end": 795
+                    "start": 0,
+                    "end": 0
                 }
             }
         }
 
         try:
-            anno = TextAnnotation(post_slug=post_slug, json=default_w3c_template)
-            anno.save()
-
-            position = request.data["position"]
-
-            default_w3c_template["id"] = default_url.split("post")[0] + str(anno.id)
             default_w3c_template["body"]["value"] = request.data["data"]["text"]
             default_w3c_template["target"]["source"] = request.data["data"]["source"]
+            position = request.data["position"]
 
             default_w3c_template["target"]["selector"]["start"] = position["start"]
             default_w3c_template["target"]["selector"]["end"] = position["end"]
 
-            anno.json = default_w3c_template
-            serializer = TextAnnotationSerializer(anno)
+            anno = TextAnnotation(post_slug=post_slug, json=default_w3c_template)
+
             anno.save()
+
+            default_w3c_template["id"] = default_url.split("post")[0] + str(anno.id)
+            anno.json = default_w3c_template
+
+            anno.save()
+
+            serializer = TextAnnotationSerializer(anno)
 
             return Response(serializer.data["json"], status=status.HTTP_201_CREATED)
         except Exception as e:


### PR DESCRIPTION
It creates text-annotation model, serializer, urls and the views. There are two APIView classes. One of them returns an annotation by the annotation id. The other one has two endpoints. Get endpoint returns a list of annotations for the given post. Post endpoint creates an annotation with the appropriate body. These endpoints are compatible with [Web Annotation Data Model](https://www.w3.org/TR/annotation-model/).