### PR TITLE
Frontend Bug: Search Results Container Remove Search Bar

### DIFF
--- a/heka-front/src/components/Navbar/Navbar.js
+++ b/heka-front/src/components/Navbar/Navbar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NavLink as Link } from 'react-router-dom';
 import './Navbar.css';
+import SearchBar from '../SearchBar/SearchBar'
 import { FaBars } from 'react-icons/fa';
 
 const Navbar = ({ isLogged, userName }) => {
@@ -23,8 +24,9 @@ const Navbar = ({ isLogged, userName }) => {
               Edit Profile
             </Link>
           )}
-          <SearchBar />
+          
         </div>
+        <SearchBar />
         {!isLogged ? (
           <div className='navv-button'>
             <Link to='/sign-in' className='navv-button-link'>

--- a/heka-front/src/components/SearchBar/SearchBar.css
+++ b/heka-front/src/components/SearchBar/SearchBar.css
@@ -14,6 +14,10 @@
   height: 60px;
   width: 300px;
 }
+.search-container {
+  margin-top: 10px;
+  
+}
 
 .searchIcon {
   height: 60px;
@@ -45,6 +49,8 @@
   box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
   overflow: hidden;
   overflow-y: auto;
+  width: 80%;
+  margin-left: 20%;
 }
 
 .dataResult::-webkit-scrollbar {

--- a/heka-front/src/pages/SignUpPage/SignUpPage.js
+++ b/heka-front/src/pages/SignUpPage/SignUpPage.js
@@ -344,9 +344,11 @@ const SignUpPage = () => {
                             />
                           </div>
                         )}
+                        
                       </>
+                      
                     ))}
-
+                     
                     <button
                       className='sign-up-button'
                       onClick={handleDoctorSubmit}
@@ -355,10 +357,29 @@ const SignUpPage = () => {
                       <AiOutlineLogin aria-hidden='true' />
                     </button>
                   </div>
+                  
+                            
+                                <input 
+                                    className="class-kvkk"
+                                    type="checkbox"
+                                    data-testid="kvkk"
+                                    
+                                />
+                                <span> I have read the {" "}<a href="https://www.nvi.gov.tr/kvkk-aydinlatma-metni" target="_blank" rel="noopener noreferrer" className="registerKVKK">
+                                        clarification on KVKK
+                                    </a> and agree on all the terms and conditions.
+                                </span>
+                                
+                           
+                        
+                
                 </div>
+                
               </form>
             </div>
+            
           </Content>
+          
         </>
       )}
     </>


### PR DESCRIPTION
### About Bug:
I realized that when search results are listed, search bar disappear in last version of the our system. The reason of this problem is using "display: flex" option for the navbar menu. Since search bar is placed in navbar menu, search bar and result container try to  place flexible due to this oprtion when results container is activated when there is matching result with entered keyword.
As a result of this, search bar is disapper. I resolved this issue putting search bar next to navbar menu instead of inside of it.

Other problem is size of "results" container. There is a inconsistency with size of the search bar. I also have resolved this bug resizing results container(pop-up) again.

You can see current version of search bar as follows: 

![image](https://user-images.githubusercontent.com/74484731/209475701-121e70d2-0f67-4e99-8468-2a3729fa1fb9.png)

➡️ For more details, you can look at #555  





### 🔎 Reviewer:  
 @umutdenizsenerr 
### ⏰ Deadline: 
25.12.2022 23.59