### PR TITLE
Frontend: Comment Orders are Added.

### DIFF
--- a/heka-front/src/components/CommentBox/CommentBox.js
+++ b/heka-front/src/components/CommentBox/CommentBox.js
@@ -20,9 +20,17 @@ const CommentBox = ({ slug, changeInComments, setChangeInComments }) => {
     };
     getComments(slug, authToken);
   }, [changeInComments]);
+
+  const likeSortedComments = comments.sort((a, b) => (b.upvote - b.downvote) - (a.upvote - a.downvote));
+
+  const sortedComments = likeSortedComments.sort((a, b) => b.is_expert - a.is_expert);
+
   return (
+    
     <div style={{ padding: 14, marginTop: '0.4vh' }}>
-      {comments.map((comment, index) => (
+
+      {sortedComments.map((comment, index) => (
+
         <Comment
           index={comment.id}
           key={index}
@@ -38,7 +46,9 @@ const CommentBox = ({ slug, changeInComments, setChangeInComments }) => {
           isDownvoted={comment.is_downvoted}
           slug={slug}
         />
+
       ))}
+      
     </div>
   );
 };


### PR DESCRIPTION
**Description:**

As per the requirement, I have implemented the feature to order the comments according to the number of upvotes, downvotes, and user type. The comments with more upvotes are displayed first, followed by the comments with equal upvotes and fewer downvotes. Also, the comments with expert user type always have top priority and are displayed as the first comments.

**Steps to reproduce:**

Load the page with the comment section
The comments should be displayed in the above-mentioned order

**Expected result:**

The comments should be displayed in the order mentioned above

**Actual result:**

The comments are displayed in the required order

**Notes:**

I have tested this feature on multiple devices and it is working as expected. Please let me know if you have any issues or concerns regarding this feature.